### PR TITLE
fix syntax errors if running in linux shell

### DIFF
--- a/pivio-with-examples.sh
+++ b/pivio-with-examples.sh
@@ -32,7 +32,7 @@ if ! type "curl" > /dev/null; then
 fi
 
 
-if [ "$OS" == "Darwin" ]; then
+if [ "$OS" = "Darwin" ]; then
 
    NATIVE_DOCKER_CMD=`docker ps`
    NATIVE_DOCKER=`echo $?`
@@ -66,9 +66,9 @@ fi
 
 # Start cloning the repositories.
 
-repos=(pivio-web pivio-server pivio-client pivio-demo-data)
+repos="pivio-web pivio-server pivio-client pivio-demo-data"
 
-for repo in ${repos[@]}
+for repo in ${repos}
 do
    echo $repo
    if [ -d "$repo" ]
@@ -143,7 +143,7 @@ if [ $? -eq 0 ]; then
   done
 
   echo "Open your webbrowser and point it to $HOSTNAME:8080";
-  if [ $OS == "Darwin" ]; then
+  if [ $OS = "Darwin" ]; then
     open "http://$HOSTNAME:8080"
   fi
 else

--- a/pivio.sh
+++ b/pivio.sh
@@ -32,7 +32,7 @@ if ! type "curl" > /dev/null; then
 fi
 
 
-if [ "$OS" == "Darwin" ]; then
+if [ "$OS" = "Darwin" ]; then
 
    NATIVE_DOCKER_CMD=`docker ps`
    NATIVE_DOCKER=`echo $?`
@@ -65,9 +65,9 @@ fi
 
 # Start cloning the repositories.
 
-repos=(pivio-web pivio-server pivio-client)
+repos="pivio-web pivio-server pivio-client"
 
-for repo in ${repos[@]}
+for repo in ${repos}
 do
    echo $repo
    if [ -d "$repo" ]
@@ -157,7 +157,7 @@ if [ $? -eq 0 ]; then
   done
 
   echo "Open your webbrowser and point it to $HOSTNAME:8080";
-  if [ $OS == "Darwin" ]; then
+  if [ "$OS" = "Darwin" ]; then
     open "http://$HOSTNAME:8080"
   fi
 else


### PR DESCRIPTION
Fix errors executing the boot scripts on Linux.

    pivio.sh: 35: [: Linux: unexpected operator
    pivio.sh: 68: pivio.sh: Syntax error: "(" unexpected