### PR TITLE
Fix `docker-compose up`.

### DIFF
--- a/demo.sh
+++ b/demo.sh
@@ -115,7 +115,7 @@ pivio-server:
    - "/dev/urandom:/dev/random"
 elasticsearch:
   image: elasticsearch:2.4.6
-  command: ["/bin/sh", "-c", "plugin install delete-by-query && gosu elasticsearch elasticsearch"]
+  command: ["/bin/sh", "-c", "plugin install delete-by-query; gosu elasticsearch elasticsearch"]
   devices:
    - "/dev/urandom:/dev/random"
 EOF

--- a/pivio.sh
+++ b/pivio.sh
@@ -115,7 +115,7 @@ pivio-server:
    - "/dev/urandom:/dev/random"
 elasticsearch:
   image: elasticsearch:2.4.6
-  command: ["/bin/sh", "-c", "plugin install delete-by-query && gosu elasticsearch elasticsearch"]
+  command: ["/bin/sh", "-c", "plugin install delete-by-query; gosu elasticsearch elasticsearch"]
   devices:
    - "/dev/urandom:/dev/random"
 EOF


### PR DESCRIPTION
`plugin install delete-by-query` fails if the plugin is already installed, so the startup command for the `elasticsearch` container needs to ignore its exit status.