### PR TITLE
Make demo.sh work out-of-the-box again with JDK 11 and Docker Compose V2

### DIFF
--- a/demo.sh
+++ b/demo.sh
@@ -91,33 +91,34 @@ done
 
 rm -r docker-compose.yml > /dev/null
 cat <<EOF > docker-compose.yml
-pivio-web:
-  build: pivio-web/
-  ports:
-   - "8080:8080"
-  links:
-   - pivio-server
-  volumes:
-   - $PWD/pivio-conf/:/pivio-conf
-  environment:
-   - PIVIO_SERVER=http://pivio-server:9123
-   - PIVIO_SERVER_JS=http://$HOSTNAME:9123
-   - PIVIO_VIEW=http://$HOSTNAME:8080
-  devices:
-   - "/dev/urandom:/dev/random"
-pivio-server:
-  build: pivio-server/
-  ports:
-   - "9123:9123"
-  links:
-   - elasticsearch
-  devices:
-   - "/dev/urandom:/dev/random"
-elasticsearch:
-  image: elasticsearch:2.4.6
-  command: ["/bin/sh", "-c", "if ! plugin list | grep -q delete-by-query; then plugin install delete-by-query; fi && gosu elasticsearch elasticsearch"]
-  devices:
-   - "/dev/urandom:/dev/random"
+services:
+  pivio-web:
+    build: pivio-web/
+    ports:
+     - "8080:8080"
+    links:
+     - pivio-server
+    volumes:
+     - $PWD/pivio-conf/:/pivio-conf
+    environment:
+     - PIVIO_SERVER=http://pivio-server:9123
+     - PIVIO_SERVER_JS=http://$HOSTNAME:9123
+     - PIVIO_VIEW=http://$HOSTNAME:8080
+    devices:
+     - "/dev/urandom:/dev/random"
+  pivio-server:
+    build: pivio-server/
+    ports:
+     - "9123:9123"
+    links:
+     - elasticsearch
+    devices:
+     - "/dev/urandom:/dev/random"
+  elasticsearch:
+    image: elasticsearch:2.4.6
+    command: ["/bin/sh", "-c", "if ! plugin list | grep -q delete-by-query; then plugin install delete-by-query; fi && gosu elasticsearch elasticsearch"]
+    devices:
+     - "/dev/urandom:/dev/random"
 EOF
 
 rm -rf pivio-conf

--- a/pivio.sh
+++ b/pivio.sh
@@ -91,33 +91,34 @@ done
 
 rm -r docker-compose.yml > /dev/null
 cat <<EOF > docker-compose.yml
-pivio-web:
-  build: pivio-web/
-  ports:
-   - "8080:8080"
-  links:
-   - pivio-server
-  volumes:
-   - $PWD/pivio-conf/:/pivio-conf
-  environment:
-   - PIVIO_SERVER=http://pivio-server:9123
-   - PIVIO_SERVER_JS=http://$HOSTNAME:9123
-   - PIVIO_VIEW=http://$HOSTNAME:8080
-  devices:
-   - "/dev/urandom:/dev/random"
-pivio-server:
-  build: pivio-server/
-  ports:
-   - "9123:9123"
-  links:
-   - elasticsearch
-  devices:
-   - "/dev/urandom:/dev/random"
-elasticsearch:
-  image: elasticsearch:2.4.6
-  command: ["/bin/sh", "-c", "if ! plugin list | grep -q delete-by-query; then plugin install delete-by-query; fi && gosu elasticsearch elasticsearch"]
-  devices:
-   - "/dev/urandom:/dev/random"
+services:
+  pivio-web:
+    build: pivio-web/
+    ports:
+     - "8080:8080"
+    links:
+     - pivio-server
+    volumes:
+     - $PWD/pivio-conf/:/pivio-conf
+    environment:
+     - PIVIO_SERVER=http://pivio-server:9123
+     - PIVIO_SERVER_JS=http://$HOSTNAME:9123
+     - PIVIO_VIEW=http://$HOSTNAME:8080
+    devices:
+     - "/dev/urandom:/dev/random"
+  pivio-server:
+    build: pivio-server/
+    ports:
+     - "9123:9123"
+    links:
+     - elasticsearch
+    devices:
+     - "/dev/urandom:/dev/random"
+  elasticsearch:
+    image: elasticsearch:2.4.6
+    command: ["/bin/sh", "-c", "if ! plugin list | grep -q delete-by-query; then plugin install delete-by-query; fi && gosu elasticsearch elasticsearch"]
+    devices:
+     - "/dev/urandom:/dev/random"
 EOF
 
 rm -rf pivio-conf


### PR DESCRIPTION
Starting the demo with
```shell
curl https://raw.githubusercontent.com/pivio/pivio-boot/master/demo.sh | /bin/sh
```
as described at <https://pivio.github.io> does not work out-of-the-box for people using:
* OpenJDK 11
* Docker Desktop 4.3.0 which uses Docker Compose V2 per default

With the current scripts, `docker-compose` fails with
```
(root) Additional property elasticsearch is not allowed
```

This merge request updates the `demo.sh` and `pivio.sh` scripts to work with Docker Compose V2.

Together with the related merge requests in `pivio-web`, `pivio-client`, and `pivio-server`, the `demo.sh` works out-of-the-box again:
* <https://github.com/pivio/pivio-server/pull/57>
* <https://github.com/pivio/pivio-web/pull/35>
* <https://github.com/pivio/pivio-client/pull/60>