### PR TITLE
Fixes for running demo.sh and pivio.sh via piping them into /bin/sh

### DIFF
--- a/demo.sh
+++ b/demo.sh
@@ -60,7 +60,11 @@ if [ "$OS" = "Darwin" ]; then
     echo "\n\n EXPERIMENTAL VPN COMPATIBILITY MODE in the settings. \n\n\n"
     echo "\n Press >ENTER< to continue \n"
     echo "=================================================="
-    read
+    # A simple "read" is insufficient here as something from the script itself is read
+    # when a user runs
+    #     curl https://raw.githubusercontent.com/pivio/pivio-boot/master/demo.sh | /bin/sh
+    # Hence, we explicitly read from /dev/tty.
+    read < /dev/tty
   fi
 fi
 
@@ -82,7 +86,12 @@ do
 
    cd $repo
    if [ -e "build.gradle" ]; then
-      ./gradlew build --no-daemon
+      # The Gradle process reads from stdin. This conflicts with our intention
+      # to let users try out pivio by running
+      #   curl https://raw.githubusercontent.com/pivio/pivio-boot/master/demo.sh | /bin/sh
+      # So, we start it in a sub shell with its own empty stdin.
+      # See <https://github.com/gradle/gradle/issues/14961>.
+      (echo -n | ./gradlew build --no-daemon)
    fi
    cd ..
 done

--- a/pivio.sh
+++ b/pivio.sh
@@ -60,7 +60,11 @@ if [ "$OS" = "Darwin" ]; then
     echo "\n\n EXPERIMENTAL VPN COMPATIBILITY MODE in the settings. \n\n\n"
     echo "\n Press >ENTER< to continue \n"
     echo "=================================================="
-    read
+    # A simple "read" is insufficient here as something from the script itself is read
+    # when a user runs
+    #     curl https://raw.githubusercontent.com/pivio/pivio-boot/master/demo.sh | /bin/sh
+    # Hence, we explicitly read from /dev/tty.
+    read < /dev/tty
   fi
 fi
 
@@ -82,7 +86,12 @@ do
 
    cd $repo
    if [ -e "build.gradle" ]; then
-      ./gradlew build --no-daemon
+      # The Gradle process reads from stdin. This conflicts with our intention
+      # to let users try out pivio by running
+      #   curl https://raw.githubusercontent.com/pivio/pivio-boot/master/demo.sh | /bin/sh
+      # So, we start it in a sub shell with its own empty stdin.
+      # See <https://github.com/gradle/gradle/issues/14961>.
+      (echo -n | ./gradlew build --no-daemon)
    fi
    cd ..
 done


### PR DESCRIPTION
Starting the demo with
```shell
curl https://raw.githubusercontent.com/pivio/pivio-boot/master/demo.sh | /bin/sh
```
as described at <https://pivio.github.io> still does not work out-of-the-box.

https://github.com/pivio/pivio-boot/pull/7 failed to fix all issues.

There are still two issues:
  1. The `read` after the "You seem like to run docker mac beta" banner is effectively skipped.
  2. The Gradle process does not exit after having built `pivio-web` causing the setup scripts to hang indefinitely.

The changes in this merge request deal with both of these issues. See the comments there for more details.

(The described problems can only be observed if the respective script is piped to the shell. The script runs as intended if it is instead first saved locally and then run via e.g. `./demo.sh`.)